### PR TITLE
feat: CD on staging branch (#32)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,61 @@
+name: Compile and push client and server to staging
+
+on:
+  push:
+    branches: ["staging"]
+  workflow_dispatch:
+
+jobs:
+  build-and-push-server-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME  }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: "{{defaultContext}}:backend"
+          file: "Dockerfile.prod"
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/mes-films-favoris-staging-server
+
+  build-and-push-client-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME  }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: "{{defaultContext}}:frontend"
+          file: "Dockerfile.prod"
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/mes-films-favoris-staging-client
+          build-args: |
+            VITE_BACKEND_URL=https://api.staging.mesfilmsfavoris.duckdns.org
+            VITE_API_KEY=d1195e56de3a08fa85ce12980ecb94b4
+
+  notify:
+    needs:
+      - build-and-push-server-staging
+      - build-and-push-client-staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call VPS webhook to update staging
+        uses: wei/curl@master
+        with:
+          args: https://ops.mesfilmsfavoris.duckdns.org/hooks/update-staging

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,6 +44,7 @@ services:
       MYSQL_DATABASE: films
     volumes:
       - ./docker/mysql/init:/docker-entrypoint-initdb.d
+      - db-data-prod:/var/lib/mysql
     networks:
       - prod-network
 
@@ -52,4 +53,4 @@ networks:
     driver: bridge
 
 volumes:
-  db-data:
+  db-data-prod:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,49 @@
+services:
+  client_staging:
+    image: baptcave/mes-films-favoris-staging-client
+    container_name: mff-staging-client
+    ports:
+      - "3001:3000"
+    networks:
+      - staging-network
+
+  server_staging:
+    image: baptcave/mes-films-favoris-staging-server
+    container_name: mff-staging-server
+    depends_on:
+      - db_staging
+    environment:
+      APP_PORT: 8000
+      FRONTEND_URL: https://staging.mesfilmsfavoris.duckdns.org
+      JWT_SECRET: baptou47
+      DB_HOST: db_staging
+      DB_PORT: 3306
+      DB_USER: baptiste
+      DB_PASSWORD: CarniBAL--18/
+      DB_NAME: films
+      CORS_ALLOWED_ORIGINS: "https://staging.mesfilmsfavoris.duckdns.org,https://api.staging.mesfilmsfavoris.duckdns.org"
+    ports:
+      - "8001:8000"
+    networks:
+      - staging-network
+
+  db_staging:
+    image: mysql:8.3
+    container_name: mff-staging-db
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpsd
+      MYSQL_USER: baptiste
+      MYSQL_PASSWORD: CarniBAL--18/
+      MYSQL_DATABASE: films
+    volumes:
+      - ./docker/mysql/init:/docker-entrypoint-initdb.d
+      - db-data-staging:/var/lib/mysql
+    networks:
+      - staging-network
+
+networks:
+  staging-network:
+    driver: bridge
+
+volumes:
+  db-data-staging:

--- a/fetch-and-deploy-staging.sh
+++ b/fetch-and-deploy-staging.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+git fetch origin && git reset --hard origin/staging && git clean -f -d && \
+docker compose -f docker-compose.staging.yml down && \
+docker compose -f docker-compose.staging.yml pull && \
+docker compose -f docker-compose.staging.yml up -d;


### PR DESCRIPTION
- setting build and push also on US_23/CD for testing purposes
- gave the good name to fetch-and-deploy-staging.sh
- deleted the git reset hard to keep track of current branch US_23/CD during tests
- setting build-args on workflow with build-and-push action
- adding 'staging' to title on homepage to test automatic update
- testing without client build part in docker-compose.staging
- added volumes to databases in both docker-compose prod and staging
- deleted 'staging' in homepage title to test again
- deleted US_23/CD branch name from CD workflow trigger branches and added back the git reset --hard into fetch-and-deploy-staging.sh